### PR TITLE
Tidy build script

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,9 +1,10 @@
-name: .NET Core
+name: msbuild
 
 on:
   push:
     branches: [ master ]
   pull_request:
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Previous change was wrong - it's documented that "Workflows do not run on private base repositories when you open a pull request from a forked repository." https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories

Closes #45.